### PR TITLE
Add stock components to React frontend

### DIFF
--- a/SNK_Plastic/frontend/src/App.js
+++ b/SNK_Plastic/frontend/src/App.js
@@ -1,11 +1,14 @@
 import React from 'react';
-import CommandeForm from './components/CommandeForm';
+import StockForm from './components/StockForm';
+import StockList from './components/StockList';
 
 function App() {
   return (
     <div className="App">
-      <h1>Créer une commande</h1>
-      <CommandeForm />
+      <h1>Gestion des Stocks - SNK Plastic</h1>
+      <StockForm />
+      <hr />
+      <StockList />
     </div>
   );
 }

--- a/SNK_Plastic/frontend/src/components/StockForm.js
+++ b/SNK_Plastic/frontend/src/components/StockForm.js
@@ -1,0 +1,66 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+
+function StockForm() {
+  const [formData, setFormData] = useState({
+    nom_objet: '',
+    type_objet: 'produit',
+    quantite: '',
+    date_entree: '',
+    echeance_stock: ''
+  });
+  const [loading, setLoading] = useState(false);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormData(prev => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      await axios.post('http://localhost:5000/api/stocks', formData);
+      alert('Stock ajouté avec succès');
+      setFormData({
+        nom_objet: '',
+        type_objet: 'produit',
+        quantite: '',
+        date_entree: '',
+        echeance_stock: ''
+      });
+    } catch (err) {
+      console.error('Erreur lors de l\'ajout du stock :', err);
+      alert("Erreur lors de l'ajout du stock");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <h2>Ajouter un stock</h2>
+      <label>Nom de l'objet</label>
+      <input type="text" name="nom_objet" value={formData.nom_objet} onChange={handleChange} required />
+
+      <label>Type d'objet</label>
+      <select name="type_objet" value={formData.type_objet} onChange={handleChange} required>
+        <option value="produit">produit</option>
+        <option value="matière">matière</option>
+      </select>
+
+      <label>Quantité</label>
+      <input type="number" name="quantite" value={formData.quantite} onChange={handleChange} required />
+
+      <label>Date d'entrée</label>
+      <input type="date" name="date_entree" value={formData.date_entree} onChange={handleChange} required />
+
+      <label>Échéance du stock</label>
+      <input type="date" name="echeance_stock" value={formData.echeance_stock} onChange={handleChange} />
+
+      <button type="submit" disabled={loading}>Ajouter</button>
+    </form>
+  );
+}
+
+export default StockForm;

--- a/SNK_Plastic/frontend/src/components/StockList.js
+++ b/SNK_Plastic/frontend/src/components/StockList.js
@@ -1,0 +1,50 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+
+function StockList() {
+  const [stocks, setStocks] = useState([]);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    axios.get('http://localhost:5000/api/stocks')
+      .then(res => {
+        setStocks(res.data);
+        setError(null);
+      })
+      .catch(err => {
+        console.error('Erreur lors de la récupération des stocks :', err);
+        setError('Erreur lors du chargement des stocks');
+      });
+  }, []);
+
+  return (
+    <div>
+      <h2>Liste des stocks</h2>
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+      <table>
+        <thead>
+          <tr>
+            <th>Nom</th>
+            <th>Type</th>
+            <th>Quantité</th>
+            <th>Date entrée</th>
+            <th>Échéance</th>
+          </tr>
+        </thead>
+        <tbody>
+          {stocks.map(stock => (
+            <tr key={stock.id || stock.stock_id || `${stock.nom_objet}-${stock.date_entree}`}> 
+              <td>{stock.nom_objet}</td>
+              <td>{stock.type_objet}</td>
+              <td>{stock.quantite}</td>
+              <td>{stock.date_entree}</td>
+              <td>{stock.echeance_stock}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default StockList;


### PR DESCRIPTION
## Summary
- add `StockForm` and `StockList` components
- update `App.js` to display stock management UI

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844896eb678832c856e22d2f38e7d47