### PR TITLE
Add production tracking module

### DIFF
--- a/SNK_Plastic/Backend/app.js
+++ b/SNK_Plastic/Backend/app.js
@@ -12,11 +12,13 @@ const commandesRoutes = require('./routes/commandes');
 const clientsRoutes = require('./routes/clients');
 const machinesRoutes = require('./routes/machines');
 const stocksRoutes = require('./routes/stocks');
+const productionRoutes = require('./routes/production');
 
 app.use('/api/commandes', commandesRoutes);
 app.use('/api/clients', clientsRoutes);
 app.use('/api/machines', machinesRoutes);
 app.use('/api/stocks', stocksRoutes);
+app.use('/api/production', productionRoutes);
 
 app.get('/', (req, res) => {
   res.send('API SNK Plastic opérationnelle ✔');

--- a/SNK_Plastic/Backend/controllers/productionController.js
+++ b/SNK_Plastic/Backend/controllers/productionController.js
@@ -1,0 +1,141 @@
+const pool = require('../db');
+
+// Get list of active manufacturing orders
+const getOFs = async (req, res) => {
+  try {
+    const query = `SELECT of.id AS numero_of, c.nom AS client, m.nom AS machine,
+                          of.temps_ecoule, of.temps_restant, of.etat
+                   FROM ordres_fabrication of
+                   JOIN clients c ON of.client_id = c.id
+                   JOIN machines m ON of.machine_id = m.id
+                   WHERE of.etat != 'termine'`;
+    const { rows } = await pool.query(query);
+    res.json(rows);
+  } catch (error) {
+    console.error('Erreur lors de la récupération des OFs:', error);
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
+};
+
+// Get production logs with optional filters
+const getLogs = async (req, res) => {
+  const { machine_id, client_id, date } = req.query;
+  const conditions = [];
+  const values = [];
+  let idx = 1;
+  let query = `SELECT pl.*, c.nom AS client, m.nom AS machine
+               FROM production_logs pl
+               JOIN ordres_fabrication of ON pl.of_id = of.id
+               JOIN clients c ON of.client_id = c.id
+               JOIN machines m ON pl.machine_id = m.id`;
+
+  if (machine_id) {
+    conditions.push(`pl.machine_id = $${idx++}`);
+    values.push(machine_id);
+  }
+  if (client_id) {
+    conditions.push(`of.client_id = $${idx++}`);
+    values.push(client_id);
+  }
+  if (date) {
+    conditions.push(`CAST(pl.date_heure AS DATE) = $${idx++}`);
+    values.push(date);
+  }
+  if (conditions.length > 0) {
+    query += ' WHERE ' + conditions.join(' AND ');
+  }
+  query += ' ORDER BY pl.date_heure DESC';
+
+  try {
+    const { rows } = await pool.query(query, values);
+    res.json(rows);
+  } catch (error) {
+    console.error('Erreur lors de la récupération des logs:', error);
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
+};
+
+// Get aggregated stats for graphs
+const getStats = async (req, res) => {
+  try {
+    const query = `SELECT CAST(pl.date_heure AS DATE) AS jour,
+                          SUM(pl.quantite_produite) AS quantite_produite,
+                          SUM(pl.quantite_rebuts) AS quantite_rebuts
+                   FROM production_logs pl
+                   GROUP BY jour
+                   ORDER BY jour`;
+    const { rows } = await pool.query(query);
+    res.json(rows);
+  } catch (error) {
+    console.error('Erreur lors de la récupération des stats:', error);
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
+};
+
+// Mark a manufacturing order as started
+const startOF = async (req, res) => {
+  const { of_id } = req.body;
+  try {
+    await pool.query(
+      'UPDATE ordres_fabrication SET temps_ecoule = 0, etat = $1 WHERE id = $2',
+      ['En cours', of_id]
+    );
+    res.json({ message: 'OF démarré' });
+  } catch (error) {
+    console.error('Erreur lors du démarrage de l\'OF:', error);
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
+};
+
+// Update manufacturing progress
+const updateOF = async (req, res) => {
+  const {
+    of_id,
+    machine_id,
+    temps_ecoule,
+    temps_restant,
+    quantite_produite,
+    quantite_rebuts,
+  } = req.body;
+
+  try {
+    await pool.query(
+      'UPDATE ordres_fabrication SET temps_ecoule = $1, temps_restant = $2 WHERE id = $3',
+      [temps_ecoule, temps_restant, of_id]
+    );
+
+    await pool.query(
+      'INSERT INTO production_logs(of_id, machine_id, quantite_produite, quantite_rebuts) VALUES($1,$2,$3,$4)',
+      [of_id, machine_id, quantite_produite, quantite_rebuts]
+    );
+
+    res.json({ message: 'OF mis à jour' });
+  } catch (error) {
+    console.error('Erreur lors de la mise à jour de l\'OF:', error);
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
+};
+
+// Add rejects entry
+const addRebuts = async (req, res) => {
+  const { of_id, machine_id, quantite_rebuts } = req.body;
+  try {
+    await pool.query(
+      'INSERT INTO production_logs(of_id, machine_id, quantite_produite, quantite_rebuts) VALUES ($1, $2, $3, $4)',
+      [of_id, machine_id, 0, quantite_rebuts]
+    );
+    res.status(201).json({ message: 'Rebuts ajoutés' });
+  } catch (error) {
+    console.error('Erreur lors de l\'ajout des rebuts:', error);
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
+};
+
+module.exports = {
+  getOFs,
+  getLogs,
+  getStats,
+  startOF,
+  updateOF,
+  addRebuts,
+};

--- a/SNK_Plastic/Backend/routes/production.js
+++ b/SNK_Plastic/Backend/routes/production.js
@@ -1,0 +1,19 @@
+const express = require('express');
+const router = express.Router();
+const {
+  getOFs,
+  getLogs,
+  getStats,
+  startOF,
+  updateOF,
+  addRebuts,
+} = require('../controllers/productionController');
+
+router.get('/ofs', getOFs);
+router.get('/logs', getLogs);
+router.get('/stats', getStats);
+router.post('/start', startOF);
+router.put('/update', updateOF);
+router.post('/rebuts', addRebuts);
+
+module.exports = router;

--- a/SNK_Plastic/frontend/package-lock.json
+++ b/SNK_Plastic/frontend/package-lock.json
@@ -13,7 +13,9 @@
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^13.5.0",
         "axios": "^1.9.0",
+        "chart.js": "^4.4.1",
         "react": "^19.1.0",
+        "react-chartjs-2": "^5.2.0",
         "react-dom": "^19.1.0",
         "react-scripts": "5.0.1",
         "web-vitals": "^2.1.4"
@@ -2958,6 +2960,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
@@ -5553,6 +5561,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.9.tgz",
+      "integrity": "sha512-EyZ9wWKgpAU0fLJ43YAEIF8sr5F2W3LqbS40ZJyHIner2lY14ufqv2VMp69MAiZ2rpwxEUxEhIH/0U3xyRynxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/check-types": {
@@ -13825,6 +13845,16 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/react-chartjs-2": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.0.tgz",
+      "integrity": "sha512-UfZZFnDsERI3c3CZGxzvNJd02SHjaSJ8kgW1djn65H1KK8rehwTjyrRKOG3VTMG8wtHZ5rgAO5oTHtHi9GCCmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-dev-utils": {

--- a/SNK_Plastic/frontend/package.json
+++ b/SNK_Plastic/frontend/package.json
@@ -8,6 +8,8 @@
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^13.5.0",
     "axios": "^1.9.0",
+    "chart.js": "^4.4.1",
+    "react-chartjs-2": "^5.2.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-scripts": "5.0.1",

--- a/SNK_Plastic/frontend/src/App.js
+++ b/SNK_Plastic/frontend/src/App.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import StockForm from './components/StockForm';
 import StockList from './components/StockList';
+import SuiviProductionPage from './components/production/SuiviProductionPage';
 
 function App() {
   return (
@@ -9,6 +10,8 @@ function App() {
       <StockForm />
       <hr />
       <StockList />
+      <hr />
+      <SuiviProductionPage />
     </div>
   );
 }

--- a/SNK_Plastic/frontend/src/components/production/OFList.js
+++ b/SNK_Plastic/frontend/src/components/production/OFList.js
@@ -1,0 +1,67 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+
+function OFList() {
+  const [ofs, setOfs] = useState([]);
+  const [clientFilter, setClientFilter] = useState('');
+  const [machineFilter, setMachineFilter] = useState('');
+  const [loaded, setLoaded] = useState(false);
+
+  const fetchOfs = async () => {
+    try {
+      const params = {};
+      if (clientFilter) params.client_id = clientFilter;
+      if (machineFilter) params.machine_id = machineFilter;
+      const res = await axios.get('http://localhost:5000/api/production/ofs', { params });
+      setOfs(res.data);
+      setLoaded(true);
+    } catch (err) {
+      console.error('Erreur lors du chargement des OFs:', err);
+    }
+  };
+
+  useEffect(() => {
+    fetchOfs();
+    const interval = setInterval(fetchOfs, 10000);
+    return () => clearInterval(interval);
+  }, [clientFilter, machineFilter]);
+
+  return (
+    <div>
+      <h2>Ordres de fabrication en cours</h2>
+      {loaded && <p>TEST OK</p>}
+      <div>
+        <label>Filtrer par client:</label>
+        <input value={clientFilter} onChange={e => setClientFilter(e.target.value)} />
+        <label>Filtrer par machine:</label>
+        <input value={machineFilter} onChange={e => setMachineFilter(e.target.value)} />
+      </div>
+      <table>
+        <thead>
+          <tr>
+            <th>N° OF</th>
+            <th>Client</th>
+            <th>Machine</th>
+            <th>Temps écoulé</th>
+            <th>Temps restant</th>
+            <th>État</th>
+          </tr>
+        </thead>
+        <tbody>
+          {ofs.map(of => (
+            <tr key={of.numero_of}>
+              <td>{of.numero_of}</td>
+              <td>{of.client}</td>
+              <td>{of.machine}</td>
+              <td>{of.temps_ecoule}</td>
+              <td>{of.temps_restant}</td>
+              <td>{of.etat}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default OFList;

--- a/SNK_Plastic/frontend/src/components/production/ProductionControls.js
+++ b/SNK_Plastic/frontend/src/components/production/ProductionControls.js
@@ -1,0 +1,78 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+
+function ProductionControls() {
+  const [formData, setFormData] = useState({
+    of_id: '',
+    machine_id: '',
+    temps_ecoule: '',
+    temps_restant: '',
+    quantite_produite: '',
+    quantite_rebuts: '',
+  });
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const startProduction = async () => {
+    try {
+      await axios.post('http://localhost:5000/api/production/start', { of_id: formData.of_id });
+      alert('Production démarrée');
+    } catch (err) {
+      console.error('Erreur start:', err);
+    }
+  };
+
+  const updateProduction = async () => {
+    try {
+      await axios.put('http://localhost:5000/api/production/update', formData);
+      alert('Production mise à jour');
+    } catch (err) {
+      console.error('Erreur update:', err);
+    }
+  };
+
+  const declareRebuts = async () => {
+    try {
+      await axios.post('http://localhost:5000/api/production/rebuts', {
+        of_id: formData.of_id,
+        machine_id: formData.machine_id,
+        quantite_rebuts: formData.quantite_rebuts,
+      });
+      alert('Rebuts déclarés');
+    } catch (err) {
+      console.error('Erreur rebuts:', err);
+    }
+  };
+
+  return (
+    <div>
+      <h2>Contrôles production</h2>
+      <div>
+        <label>OF ID</label>
+        <input name="of_id" value={formData.of_id} onChange={handleChange} />
+        <label>Machine ID</label>
+        <input name="machine_id" value={formData.machine_id} onChange={handleChange} />
+      </div>
+      <div>
+        <label>Temps écoulé</label>
+        <input name="temps_ecoule" value={formData.temps_ecoule} onChange={handleChange} />
+        <label>Temps restant</label>
+        <input name="temps_restant" value={formData.temps_restant} onChange={handleChange} />
+      </div>
+      <div>
+        <label>Quantité produite</label>
+        <input name="quantite_produite" value={formData.quantite_produite} onChange={handleChange} />
+        <label>Quantité rebuts</label>
+        <input name="quantite_rebuts" value={formData.quantite_rebuts} onChange={handleChange} />
+      </div>
+      <button onClick={startProduction}>Démarrer production</button>
+      <button onClick={updateProduction}>Mettre à jour</button>
+      <button onClick={declareRebuts}>Déclarer rebuts</button>
+    </div>
+  );
+}
+
+export default ProductionControls;

--- a/SNK_Plastic/frontend/src/components/production/ProductionGraph.js
+++ b/SNK_Plastic/frontend/src/components/production/ProductionGraph.js
@@ -1,0 +1,61 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import { Bar } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
+
+function ProductionGraph() {
+  const [data, setData] = useState({ labels: [], rebuts: [], produite: [] });
+
+  const fetchStats = async () => {
+    try {
+      const res = await axios.get('http://localhost:5000/api/production/stats');
+      const labels = res.data.map(row => row.jour);
+      const produite = res.data.map(row => row.quantite_produite);
+      const rebuts = res.data.map(row => row.quantite_rebuts);
+      setData({ labels, produite, rebuts });
+    } catch (err) {
+      console.error('Erreur lors du chargement des stats:', err);
+    }
+  };
+
+  useEffect(() => {
+    fetchStats();
+    const interval = setInterval(fetchStats, 10000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const chartData = {
+    labels: data.labels,
+    datasets: [
+      {
+        label: 'Produits',
+        backgroundColor: 'rgba(75,192,192,0.4)',
+        data: data.produite,
+      },
+      {
+        label: 'Rebuts',
+        backgroundColor: 'rgba(255,99,132,0.4)',
+        data: data.rebuts,
+      },
+    ],
+  };
+
+  return (
+    <div>
+      <h2>Production quotidienne</h2>
+      <Bar data={chartData} />
+    </div>
+  );
+}
+
+export default ProductionGraph;

--- a/SNK_Plastic/frontend/src/components/production/SuiviProductionPage.js
+++ b/SNK_Plastic/frontend/src/components/production/SuiviProductionPage.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import OFList from './OFList';
+import ProductionGraph from './ProductionGraph';
+import ProductionControls from './ProductionControls';
+
+function SuiviProductionPage() {
+  return (
+    <div>
+      <h1>Suivi de production</h1>
+      <ProductionControls />
+      <OFList />
+      <ProductionGraph />
+    </div>
+  );
+}
+
+export default SuiviProductionPage;


### PR DESCRIPTION
## Summary
- add production controller and routes for backend
- integrate production routes in Express app
- add React components for production tracking
- integrate production page in frontend
- add chart dependencies

## Testing
- `npm test --silent` (backend)
- `npm test --silent` (frontend)

------
https://chatgpt.com/codex/tasks/task_e_6845a1733ef8832cad794df623072d67