### PR TITLE
Implement factures module

### DIFF
--- a/SNK_Plastic/Backend/app.js
+++ b/SNK_Plastic/Backend/app.js
@@ -13,12 +13,14 @@ const clientsRoutes = require('./routes/clients');
 const machinesRoutes = require('./routes/machines');
 const stocksRoutes = require('./routes/stocks');
 const productionRoutes = require('./routes/production');
+const facturesRoutes = require('./routes/factures');
 
 app.use('/api/commandes', commandesRoutes);
 app.use('/api/clients', clientsRoutes);
 app.use('/api/machines', machinesRoutes);
 app.use('/api/stocks', stocksRoutes);
 app.use('/api/production', productionRoutes);
+app.use('/api/factures', facturesRoutes);
 
 app.get('/', (req, res) => {
   res.send('API SNK Plastic opérationnelle ✔');

--- a/SNK_Plastic/Backend/controllers/facturesController.js
+++ b/SNK_Plastic/Backend/controllers/facturesController.js
@@ -1,0 +1,92 @@
+const pool = require('../db');
+
+const getAllFactures = async (req, res) => {
+  try {
+    const { rows } = await pool.query('SELECT * FROM factures ORDER BY id');
+    res.json(rows);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
+};
+
+const getFactureById = async (req, res) => {
+  const { id } = req.params;
+  try {
+    const { rows } = await pool.query('SELECT * FROM factures WHERE id = $1', [id]);
+    if (rows.length === 0) {
+      return res.status(404).json({ error: 'Facture non trouvée' });
+    }
+    res.json(rows[0]);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
+};
+
+const generateNumeroFacture = async () => {
+  const { rows } = await pool.query('SELECT numero_facture FROM factures ORDER BY id DESC LIMIT 1');
+  if (rows.length === 0) {
+    return 'F-001';
+  }
+  const match = rows[0].numero_facture.match(/F-(\d+)/);
+  const next = match ? parseInt(match[1], 10) + 1 : 1;
+  return `F-${String(next).padStart(3, '0')}`;
+};
+
+const createFacture = async (req, res) => {
+  const { client_id, produit_id, date_emission, montant_total, montant_paye, pdf_facture } = req.body;
+  try {
+    const numero = await generateNumeroFacture();
+    const { rows } = await pool.query(
+      `INSERT INTO factures (numero_facture, client_id, produit_id, date_emission, montant_total, montant_paye, pdf_facture)
+       VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING *`,
+      [numero, client_id, produit_id, date_emission, montant_total, montant_paye, pdf_facture || null]
+    );
+    res.status(201).json(rows[0]);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
+};
+
+const updateFacture = async (req, res) => {
+  const { id } = req.params;
+  const { client_id, produit_id, date_emission, montant_total, montant_paye, pdf_facture } = req.body;
+  try {
+    const { rows } = await pool.query(
+      `UPDATE factures SET client_id=$1, produit_id=$2, date_emission=$3, montant_total=$4, montant_paye=$5, pdf_facture=$6 WHERE id=$7 RETURNING *`,
+      [client_id, produit_id, date_emission, montant_total, montant_paye, pdf_facture || null, id]
+    );
+    if (rows.length === 0) {
+      return res.status(404).json({ error: 'Facture non trouvée' });
+    }
+    res.json(rows[0]);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
+};
+
+const deleteFacture = async (req, res) => {
+  const { id } = req.params;
+  try {
+    const result = await pool.query('DELETE FROM factures WHERE id = $1', [id]);
+    if (result.rowCount === 0) {
+      return res.status(404).json({ error: 'Facture non trouvée' });
+    }
+    res.json({ message: 'Facture supprimée' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
+};
+
+module.exports = {
+  getAllFactures,
+  getFactureById,
+  createFacture,
+  updateFacture,
+  deleteFacture,
+};
+

--- a/SNK_Plastic/Backend/routes/factures.js
+++ b/SNK_Plastic/Backend/routes/factures.js
@@ -1,0 +1,17 @@
+const express = require('express');
+const router = express.Router();
+const {
+  getAllFactures,
+  getFactureById,
+  createFacture,
+  updateFacture,
+  deleteFacture,
+} = require('../controllers/facturesController');
+
+router.get('/', getAllFactures);
+router.get('/:id', getFactureById);
+router.post('/', createFacture);
+router.put('/:id', updateFacture);
+router.delete('/:id', deleteFacture);
+
+module.exports = router;

--- a/SNK_Plastic/frontend/src/App.js
+++ b/SNK_Plastic/frontend/src/App.js
@@ -2,6 +2,9 @@ import React from 'react';
 import StockForm from './components/StockForm';
 import StockList from './components/StockList';
 import SuiviProductionPage from './components/production/SuiviProductionPage';
+import FactureForm from './components/factures/FactureForm';
+import FactureList from './components/factures/FactureList';
+import FactureGraph from './components/factures/FactureGraph';
 
 function App() {
   return (
@@ -10,6 +13,12 @@ function App() {
       <StockForm />
       <hr />
       <StockList />
+      <hr />
+      <FactureForm />
+      <hr />
+      <FactureList />
+      <hr />
+      <FactureGraph />
       <hr />
       <SuiviProductionPage />
     </div>

--- a/SNK_Plastic/frontend/src/components/factures/FactureDetails.js
+++ b/SNK_Plastic/frontend/src/components/factures/FactureDetails.js
@@ -1,0 +1,44 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+
+function FactureDetails({ id, onUpdated }) {
+  const [facture, setFacture] = useState(null);
+
+  useEffect(() => {
+    if (!id) return;
+    axios.get(`http://localhost:5000/api/factures/${id}`)
+      .then(res => setFacture(res.data))
+      .catch(err => console.error('Erreur chargement facture:', err));
+  }, [id]);
+
+  const handleChange = e => {
+    const { name, value } = e.target;
+    setFacture(prev => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    try {
+      await axios.put(`http://localhost:5000/api/factures/${id}`, facture);
+      alert('Facture mise à jour');
+      if (onUpdated) onUpdated();
+    } catch (err) {
+      console.error('Erreur maj facture:', err);
+    }
+  };
+
+  if (!facture) return null;
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <h3>Modifier facture {facture.numero_facture}</h3>
+      <label>Montant total</label>
+      <input type="number" name="montant_total" value={facture.montant_total} onChange={handleChange} />
+      <label>Montant payé</label>
+      <input type="number" name="montant_paye" value={facture.montant_paye} onChange={handleChange} />
+      <button type="submit">Enregistrer</button>
+    </form>
+  );
+}
+
+export default FactureDetails;

--- a/SNK_Plastic/frontend/src/components/factures/FactureForm.js
+++ b/SNK_Plastic/frontend/src/components/factures/FactureForm.js
@@ -1,0 +1,64 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+
+function FactureForm({ onCreated }) {
+  const [clients, setClients] = useState([]);
+  const [formData, setFormData] = useState({
+    client_id: '',
+    produit_id: '',
+    date_emission: '',
+    montant_total: '',
+    montant_paye: '',
+  });
+
+  useEffect(() => {
+    axios.get('http://localhost:5000/api/clients')
+      .then(res => setClients(res.data))
+      .catch(err => console.error('Erreur chargement clients:', err));
+  }, []);
+
+  const handleChange = e => {
+    const { name, value } = e.target;
+    setFormData(prev => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    try {
+      await axios.post('http://localhost:5000/api/factures', formData);
+      alert('Facture créée');
+      setFormData({ client_id: '', produit_id: '', date_emission: '', montant_total: '', montant_paye: '' });
+      if (onCreated) onCreated();
+    } catch (err) {
+      console.error('Erreur création facture:', err);
+      alert('Erreur création facture');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <h2>Créer une facture</h2>
+      <label>Client</label>
+      <select name="client_id" value={formData.client_id} onChange={handleChange} required>
+        <option value="">-- Sélectionner --</option>
+        {clients.map(c => <option key={c.id} value={c.id}>{c.nom}</option>)}
+      </select>
+
+      <label>Produit</label>
+      <input type="text" name="produit_id" value={formData.produit_id} onChange={handleChange} required />
+
+      <label>Date d'émission</label>
+      <input type="date" name="date_emission" value={formData.date_emission} onChange={handleChange} required />
+
+      <label>Montant total</label>
+      <input type="number" name="montant_total" value={formData.montant_total} onChange={handleChange} required />
+
+      <label>Montant payé</label>
+      <input type="number" name="montant_paye" value={formData.montant_paye} onChange={handleChange} required />
+
+      <button type="submit">Créer la facture</button>
+    </form>
+  );
+}
+
+export default FactureForm;

--- a/SNK_Plastic/frontend/src/components/factures/FactureGraph.js
+++ b/SNK_Plastic/frontend/src/components/factures/FactureGraph.js
@@ -1,0 +1,57 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import { Bar } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
+
+function FactureGraph() {
+  const [data, setData] = useState({ labels: [], total: [], paye: [] });
+
+  const fetchData = async () => {
+    try {
+      const res = await axios.get('http://localhost:5000/api/factures');
+      const clients = {};
+      res.data.forEach(f => {
+        if (!clients[f.client_id]) {
+          clients[f.client_id] = { total: 0, paye: 0 };
+        }
+        clients[f.client_id].total += parseFloat(f.montant_total);
+        clients[f.client_id].paye += parseFloat(f.montant_paye);
+      });
+      const labels = Object.keys(clients);
+      const total = labels.map(l => clients[l].total);
+      const paye = labels.map(l => clients[l].paye);
+      setData({ labels, total, paye });
+    } catch (err) {
+      console.error('Erreur chargement factures:', err);
+    }
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  return (
+    <div>
+      <h2>Montants facturés par client</h2>
+      <Bar data={{
+        labels: data.labels,
+        datasets: [
+          { label: 'Total', backgroundColor: 'rgba(75,192,192,0.4)', data: data.total },
+          { label: 'Payé', backgroundColor: 'rgba(255,99,132,0.4)', data: data.paye },
+        ]
+      }} />
+    </div>
+  );
+}
+
+export default FactureGraph;

--- a/SNK_Plastic/frontend/src/components/factures/FactureList.js
+++ b/SNK_Plastic/frontend/src/components/factures/FactureList.js
@@ -1,0 +1,62 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+
+function FactureList() {
+  const [factures, setFactures] = useState([]);
+
+  const fetchFactures = () => {
+    axios.get('http://localhost:5000/api/factures')
+      .then(res => setFactures(res.data))
+      .catch(err => console.error('Erreur chargement factures:', err));
+  };
+
+  useEffect(() => {
+    fetchFactures();
+  }, []);
+
+  const handleDelete = async id => {
+    if (!window.confirm('Supprimer cette facture ?')) return;
+    try {
+      await axios.delete(`http://localhost:5000/api/factures/${id}`);
+      fetchFactures();
+    } catch (err) {
+      console.error('Erreur suppression facture:', err);
+    }
+  };
+
+  return (
+    <div>
+      <h2>Liste des factures</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Numéro</th>
+            <th>Client</th>
+            <th>Produit</th>
+            <th>Date</th>
+            <th>Montant total</th>
+            <th>Montant payé</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {factures.map(f => (
+            <tr key={f.id}>
+              <td>{f.numero_facture}</td>
+              <td>{f.client_id}</td>
+              <td>{f.produit_id}</td>
+              <td>{f.date_emission}</td>
+              <td>{f.montant_total}</td>
+              <td>{f.montant_paye}</td>
+              <td>
+                <button onClick={() => handleDelete(f.id)}>Supprimer</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default FactureList;


### PR DESCRIPTION
## Summary
- add CRUD API for factures with generated invoice numbers
- expose `/api/factures` routes in the backend
- create React components for managing invoices
- display invoice components in the main app

## Testing
- `npm test` *(backend - fails: Error: no test specified)*
- `npm test -- --watchAll=false` *(frontend - fails to run due to Jest config)*

------
https://chatgpt.com/codex/tasks/task_e_6845aa86702c832c9206b9c3efdfc022