### PR TITLE
Implement admin dashboard APIs and page

### DIFF
--- a/SNK_Plastic/Backend/app.js
+++ b/SNK_Plastic/Backend/app.js
@@ -14,6 +14,7 @@ const machinesRoutes = require('./routes/machines');
 const stocksRoutes = require('./routes/stocks');
 const productionRoutes = require('./routes/production');
 const facturesRoutes = require('./routes/factures');
+const dashboardRoutes = require('./routes/dashboard');
 
 app.use('/api/commandes', commandesRoutes);
 app.use('/api/clients', clientsRoutes);
@@ -21,6 +22,7 @@ app.use('/api/machines', machinesRoutes);
 app.use('/api/stocks', stocksRoutes);
 app.use('/api/production', productionRoutes);
 app.use('/api/factures', facturesRoutes);
+app.use('/api/dashboard', dashboardRoutes);
 
 app.get('/', (req, res) => {
   res.send('API SNK Plastic opérationnelle ✔');

--- a/SNK_Plastic/Backend/controllers/dashboardController.js
+++ b/SNK_Plastic/Backend/controllers/dashboardController.js
@@ -1,0 +1,71 @@
+const pool = require('../db');
+
+// Récupère les indicateurs clés pour le tableau de bord
+const getKpis = async (req, res) => {
+  try {
+    const totalsRes = await pool.query(
+      `SELECT COALESCE(SUM(pl.quantite_produite),0) AS produits,
+              COALESCE(SUM(pl.quantite_rebuts),0) AS rebuts
+       FROM production_logs pl
+       JOIN ordres_fabrication of ON pl.of_id = of.id
+       WHERE of.etat != 'termine'`
+    );
+    const totals = totalsRes.rows[0];
+
+    const restantRes = await pool.query(
+      `SELECT COALESCE(SUM(of.quantite_commande - COALESCE(prod.qte,0)),0) AS restant
+       FROM ordres_fabrication of
+       LEFT JOIN (
+         SELECT of_id, SUM(quantite_produite) AS qte
+         FROM production_logs
+         GROUP BY of_id
+       ) prod ON prod.of_id = of.id
+       WHERE of.etat != 'termine'`
+    );
+    const restant = restantRes.rows[0].restant;
+
+    res.json({
+      total_produits_finis: parseInt(totals.produits, 10),
+      total_rebuts: parseInt(totals.rebuts, 10),
+      restant_a_produire: parseInt(restant, 10),
+    });
+  } catch (err) {
+    console.error('Erreur getKpis:', err);
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
+};
+
+// Liste les ordres de fabrication non terminés avec statistiques
+const getActiveOFs = async (req, res) => {
+  try {
+    const { rows } = await pool.query(
+      `SELECT of.id, c.nom AS client, m.nom AS machine,
+              of.quantite_commande,
+              COALESCE(prod.qte,0) AS quantite_produite,
+              COALESCE(prod.rebuts,0) AS rebuts,
+              (of.quantite_commande - COALESCE(prod.qte,0)) AS restant,
+              of.temps_ecoule,
+              of.etat
+       FROM ordres_fabrication of
+       JOIN clients c ON of.client_id = c.id
+       JOIN machines m ON of.machine_id = m.id
+       LEFT JOIN (
+         SELECT of_id, SUM(quantite_produite) AS qte,
+                SUM(quantite_rebuts) AS rebuts
+         FROM production_logs
+         GROUP BY of_id
+       ) prod ON prod.of_id = of.id
+       WHERE of.etat != 'termine'
+       ORDER BY of.id`
+    );
+    res.json(rows);
+  } catch (err) {
+    console.error('Erreur getActiveOFs:', err);
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
+};
+
+module.exports = {
+  getKpis,
+  getActiveOFs,
+};

--- a/SNK_Plastic/Backend/routes/dashboard.js
+++ b/SNK_Plastic/Backend/routes/dashboard.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+const { getKpis, getActiveOFs } = require('../controllers/dashboardController');
+
+router.get('/kpis', getKpis);
+router.get('/ofs', getActiveOFs);
+
+module.exports = router;

--- a/SNK_Plastic/frontend/src/App.js
+++ b/SNK_Plastic/frontend/src/App.js
@@ -7,6 +7,7 @@ import SuiviProductionPage from './components/production/SuiviProductionPage';
 import FactureForm from './components/factures/FactureForm';
 import FactureList from './components/factures/FactureList';
 import FactureGraph from './components/factures/FactureGraph';
+import DashboardPage from './components/dashboard/DashboardPage';
 
 function StocksPage() {
   return (
@@ -36,10 +37,11 @@ function App() {
         <SideMenu />
         <div className="content">
           <Routes>
+            <Route path="/dashboard" element={<DashboardPage />} />
             <Route path="/stocks" element={<StocksPage />} />
             <Route path="/factures" element={<FacturesPage />} />
             <Route path="/production" element={<SuiviProductionPage />} />
-            <Route path="*" element={<StocksPage />} />
+            <Route path="*" element={<DashboardPage />} />
           </Routes>
         </div>
       </div>

--- a/SNK_Plastic/frontend/src/components/SideMenu.js
+++ b/SNK_Plastic/frontend/src/components/SideMenu.js
@@ -5,6 +5,7 @@ function SideMenu() {
   return (
     <nav className="side-menu">
       <ul>
+        <li><NavLink to="/dashboard">Dashboard</NavLink></li>
         <li><NavLink to="/stocks">Stocks</NavLink></li>
         <li><NavLink to="/factures">Factures</NavLink></li>
         <li><NavLink to="/production">Suivi de production</NavLink></li>

--- a/SNK_Plastic/frontend/src/components/dashboard/DashboardKpis.js
+++ b/SNK_Plastic/frontend/src/components/dashboard/DashboardKpis.js
@@ -1,0 +1,39 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+
+function DashboardKpis() {
+  const [kpis, setKpis] = useState(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const res = await axios.get('http://localhost:5000/api/dashboard/kpis');
+        setKpis(res.data);
+      } catch (err) {
+        console.error('Erreur chargement KPIs:', err);
+      }
+    };
+    fetchData();
+  }, []);
+
+  if (!kpis) return <p>Loading...</p>;
+
+  return (
+    <div className="kpis">
+      <div className="kpi-card">
+        <h3>Produits finis</h3>
+        <p>{kpis.total_produits_finis}</p>
+      </div>
+      <div className="kpi-card">
+        <h3>Rebuts</h3>
+        <p>{kpis.total_rebuts}</p>
+      </div>
+      <div className="kpi-card">
+        <h3>Restant à produire</h3>
+        <p>{kpis.restant_a_produire}</p>
+      </div>
+    </div>
+  );
+}
+
+export default DashboardKpis;

--- a/SNK_Plastic/frontend/src/components/dashboard/DashboardPage.js
+++ b/SNK_Plastic/frontend/src/components/dashboard/DashboardPage.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import DashboardKpis from './DashboardKpis';
+import OFTable from './OFTable';
+
+function DashboardPage() {
+  return (
+    <div>
+      <h1>Dashboard</h1>
+      <DashboardKpis />
+      <OFTable />
+    </div>
+  );
+}
+
+export default DashboardPage;

--- a/SNK_Plastic/frontend/src/components/dashboard/OFTable.js
+++ b/SNK_Plastic/frontend/src/components/dashboard/OFTable.js
@@ -1,0 +1,58 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+
+function OFTable() {
+  const [ofs, setOfs] = useState(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const res = await axios.get('http://localhost:5000/api/dashboard/ofs');
+        setOfs(res.data);
+      } catch (err) {
+        console.error('Erreur chargement OF actifs:', err);
+      }
+    };
+    fetchData();
+  }, []);
+
+  if (!ofs) return <p>Loading...</p>;
+
+  return (
+    <div>
+      <h2>Ordres de fabrication actifs</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Client</th>
+            <th>Machine</th>
+            <th>Quantité commandée</th>
+            <th>Quantité produite</th>
+            <th>Rebuts</th>
+            <th>Restant</th>
+            <th>Temps écoulé</th>
+            <th>Statut</th>
+          </tr>
+        </thead>
+        <tbody>
+          {ofs.map((of) => (
+            <tr key={of.id}>
+              <td>{of.id}</td>
+              <td>{of.client}</td>
+              <td>{of.machine}</td>
+              <td>{of.quantite_commande}</td>
+              <td>{of.quantite_produite}</td>
+              <td style={{ color: of.rebuts > 0 ? 'red' : 'inherit' }}>{of.rebuts}</td>
+              <td>{of.restant}</td>
+              <td>{of.temps_ecoule}</td>
+              <td>{of.etat}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default OFTable;


### PR DESCRIPTION
## Summary
- add backend dashboard controller with KPI & active OF endpoints
- expose `/api/dashboard` routes in backend
- create React dashboard page with KPIs and OF table
- add dashboard link to menu and routing

## Testing
- `npm test` in `SNK_Plastic/Backend` *(fails: no test specified)*
- `CI=true npm test` in `SNK_Plastic/frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845bfcae038832cb4e4946edb29d6a1