### PR TITLE
Add operator interface tied to machine

### DIFF
--- a/SNK_Plastic/Backend/controllers/productionController.js
+++ b/SNK_Plastic/Backend/controllers/productionController.js
@@ -212,6 +212,25 @@ const getFilteredOFs = async (req, res) => {
     res.status(500).json({ error: 'Erreur serveur' });
   }
 };
+
+// OF actif pour une machine donnée
+const getActiveOFByMachine = async (req, res) => {
+  const { machineId } = req.params;
+  try {
+    const { rows } = await pool.query(
+      `SELECT * FROM ordres_fabrication
+       WHERE machine_id = $1 AND etat != 'termine'
+       ORDER BY id DESC
+       LIMIT 1`,
+      [machineId]
+    );
+    if (rows.length === 0) return res.status(404).json({ error: 'Aucun OF actif' });
+    res.json(rows[0]);
+  } catch (err) {
+    console.error('Erreur getActiveOFByMachine:', err);
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
+};
 // Données agrégées pour graphes
 const getGraphData = async (req, res) => {
   const { filter } = req.query;
@@ -250,4 +269,5 @@ module.exports = {
   getFilteredLogs,
   getFilteredOFs,
   getGraphData,
+  getActiveOFByMachine,
 };

--- a/SNK_Plastic/Backend/routes/production.js
+++ b/SNK_Plastic/Backend/routes/production.js
@@ -11,6 +11,7 @@ const {
   getGraphData,
   getFilteredLogs,
   getFilteredOFs,
+  getActiveOFByMachine,
 } = require('../controllers/productionController');
 
 // Ordres de fabrication
@@ -25,5 +26,6 @@ router.post('/logs', addLog);
 router.get('/logs', getLogs);
 router.get('/logs/graph', getFilteredLogs);
 router.get('/ofs', getFilteredOFs);
+router.get('/active-of/:machineId', getActiveOFByMachine);
 
 module.exports = router;

--- a/SNK_Plastic/frontend/src/App.js
+++ b/SNK_Plastic/frontend/src/App.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom';
 import SideMenu from './components/SideMenu';
 import StockForm from './components/StockForm';
 import StockList from './components/StockList';
@@ -8,6 +8,7 @@ import FactureForm from './components/factures/FactureForm';
 import FactureList from './components/factures/FactureList';
 import FactureGraph from './components/factures/FactureGraph';
 import DashboardPage from './components/dashboard/DashboardPage';
+import OperatorForm from './components/production/OperatorForm';
 
 function StocksPage() {
   return (
@@ -30,21 +31,31 @@ function FacturesPage() {
   );
 }
 
+function AppLayout() {
+  const location = useLocation();
+  const hideMenu = location.pathname.startsWith('/operator');
+
+  return (
+    <div className="app-layout">
+      {!hideMenu && <SideMenu />}
+      <div className="content">
+        <Routes>
+          <Route path="/dashboard" element={<DashboardPage />} />
+          <Route path="/stocks" element={<StocksPage />} />
+          <Route path="/factures" element={<FacturesPage />} />
+          <Route path="/production" element={<SuiviProductionPage />} />
+          <Route path="/operator/:machineId" element={<OperatorForm />} />
+          <Route path="*" element={<DashboardPage />} />
+        </Routes>
+      </div>
+    </div>
+  );
+}
+
 function App() {
   return (
     <BrowserRouter>
-      <div className="app-layout">
-        <SideMenu />
-        <div className="content">
-          <Routes>
-            <Route path="/dashboard" element={<DashboardPage />} />
-            <Route path="/stocks" element={<StocksPage />} />
-            <Route path="/factures" element={<FacturesPage />} />
-            <Route path="/production" element={<SuiviProductionPage />} />
-            <Route path="*" element={<DashboardPage />} />
-          </Routes>
-        </div>
-      </div>
+      <AppLayout />
     </BrowserRouter>
   );
 }

--- a/SNK_Plastic/frontend/src/components/production/OperatorForm.js
+++ b/SNK_Plastic/frontend/src/components/production/OperatorForm.js
@@ -1,0 +1,90 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import { useParams } from 'react-router-dom';
+
+function OperatorForm({ machineId: propMachineId }) {
+  const params = useParams();
+  const machineId = propMachineId || params.machineId;
+  const [ofId, setOfId] = useState(null);
+  const [quantite, setQuantite] = useState('');
+  const [rebuts, setRebuts] = useState('');
+  const [message, setMessage] = useState('');
+  const [cumul, setCumul] = useState(0);
+
+  const fetchCumul = async (of) => {
+    try {
+      const res = await axios.get('http://localhost:5000/api/production/logs', {
+        params: { of_id: of },
+      });
+      const total = res.data.reduce((sum, l) => sum + Number(l.quantite_produite), 0);
+      setCumul(total);
+    } catch (err) {
+      console.error('Erreur chargement cumul:', err);
+    }
+  };
+
+  const loadActiveOF = async () => {
+    try {
+      const res = await axios.get(`http://localhost:5000/api/production/active-of/${machineId}`);
+      setOfId(res.data.id);
+      fetchCumul(res.data.id);
+    } catch (err) {
+      console.error('Erreur chargement OF actif:', err);
+    }
+  };
+
+  useEffect(() => {
+    if (machineId) {
+      loadActiveOF();
+    }
+  }, [machineId]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!ofId) return;
+    try {
+      await axios.post('http://localhost:5000/api/production/logs', {
+        of_id: ofId,
+        machine_id: machineId,
+        quantite_produite: Number(quantite),
+        quantite_rebuts: rebuts ? Number(rebuts) : 0,
+      });
+      setQuantite('');
+      setRebuts('');
+      setMessage('✔ Données enregistrées');
+      fetchCumul(ofId);
+      setTimeout(() => setMessage(''), 3000);
+    } catch (err) {
+      console.error('Erreur enregistrement:', err);
+      alert("Erreur lors de l'enregistrement");
+    }
+  };
+
+  if (!ofId) return <p>Aucun ordre de fabrication actif</p>;
+
+  return (
+    <div className="operator-form">
+      <h2>Machine {machineId}</h2>
+      <p>Quantité cumulée : {cumul}</p>
+      <form onSubmit={handleSubmit}>
+        <label>Quantité produite</label>
+        <input
+          type="number"
+          value={quantite}
+          onChange={(e) => setQuantite(e.target.value)}
+          required
+        />
+        <label>Rebuts</label>
+        <input
+          type="number"
+          value={rebuts}
+          onChange={(e) => setRebuts(e.target.value)}
+        />
+        <button type="submit">Envoyer les données</button>
+      </form>
+      {message && <p>{message}</p>}
+    </div>
+  );
+}
+
+export default OperatorForm;


### PR DESCRIPTION
## Summary
- add route to get active OF by machine and controller
- integrate route in backend
- provide React OperatorForm component for tablet operator entry
- hide SideMenu on operator page and link route

## Testing
- `npm test` (fails: Error: no test specified)
- `npm test --silent` in frontend (failed: react-scripts not found)

------
https://chatgpt.com/codex/tasks/task_e_6845cd220ee8832c858df6a0197fa280