### PR TITLE
Style dashboard page

### DIFF
--- a/SNK_Plastic/frontend/src/components/dashboard/DashboardKpis.js
+++ b/SNK_Plastic/frontend/src/components/dashboard/DashboardKpis.js
@@ -21,18 +21,18 @@ function DashboardKpis({ filters }) {
   if (!kpis) return <p>Loading...</p>;
 
   return (
-    <div className="kpis">
-      <div className="kpi-card">
-        <h3>Produits finis</h3>
-        <p>{kpis.total_produits_finis}</p>
+    <div className="kpi-container">
+      <div className="kpi-box">
+        <h4>Produits finis</h4>
+        <div className="kpi-value">{kpis.total_produits_finis}</div>
       </div>
-      <div className="kpi-card">
-        <h3>Rebuts</h3>
-        <p>{kpis.total_rebuts}</p>
+      <div className="kpi-box">
+        <h4>Rebuts</h4>
+        <div className="kpi-value">{kpis.total_rebuts}</div>
       </div>
-      <div className="kpi-card">
-        <h3>Restant à produire</h3>
-        <p>{kpis.restant_a_produire}</p>
+      <div className="kpi-box">
+        <h4>Restant à produire</h4>
+        <div className="kpi-value">{kpis.restant_a_produire}</div>
       </div>
     </div>
   );

--- a/SNK_Plastic/frontend/src/components/dashboard/DashboardPage.css
+++ b/SNK_Plastic/frontend/src/components/dashboard/DashboardPage.css
@@ -1,0 +1,103 @@
+.dashboard-container {
+  display: flex;
+  min-height: 100vh;
+}
+
+.sidebar {
+  width: 220px;
+  background-color: #004aad;
+  color: #fff;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+}
+
+.sidebar h1 {
+  font-size: 20px;
+  margin: 0 0 20px;
+}
+
+.sidebar a {
+  color: #fff;
+  text-decoration: none;
+  padding: 10px 0;
+  display: block;
+}
+
+.sidebar a.active,
+.sidebar a:hover {
+  background-color: #0077cc;
+  padding-left: 5px;
+}
+
+.main-content {
+  flex: 1;
+  background-color: #f9f9f9;
+  padding: 20px;
+}
+
+.dashboard-title {
+  margin-top: 0;
+}
+
+.filters-bar {
+  margin-bottom: 20px;
+}
+
+.filters-bar select,
+.filters-bar input {
+  margin-right: 10px;
+  padding: 5px;
+}
+
+.filters-bar select:focus,
+.filters-bar input:focus,
+.sidebar a:focus {
+  outline-color: #0077cc;
+}
+
+.kpi-container {
+  display: flex;
+  gap: 20px;
+  margin-bottom: 20px;
+}
+
+.kpi-box {
+  background: #fff;
+  flex: 1;
+  padding: 15px;
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+  text-align: center;
+}
+
+.kpi-box h4 {
+  margin: 0 0 10px;
+}
+
+.kpi-value {
+  font-size: 24px;
+  font-weight: bold;
+  color: #0077cc;
+}
+
+.of-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: #fff;
+}
+
+.of-table th,
+.of-table td {
+  padding: 8px 12px;
+  border-bottom: 1px solid #ddd;
+}
+
+.of-table th {
+  background-color: #f0f0f0;
+  text-align: left;
+}
+
+.of-table tbody tr:hover {
+  background-color: #f5f5f5;
+}

--- a/SNK_Plastic/frontend/src/components/dashboard/DashboardPage.js
+++ b/SNK_Plastic/frontend/src/components/dashboard/DashboardPage.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import DashboardKpis from './DashboardKpis';
 import OFTable from './OFTable';
 import DashboardFilters from './DashboardFilters';
+import './DashboardPage.css';
 
 function DashboardPage() {
   const [filters, setFilters] = useState({
@@ -12,11 +13,27 @@ function DashboardPage() {
   });
 
   return (
-    <div>
-      <h1>Dashboard</h1>
-      <DashboardFilters onFilterChange={setFilters} />
-      <DashboardKpis filters={filters} />
-      <OFTable filters={filters} />
+    <div className="dashboard-container">
+      <aside className="sidebar">
+        <h1>SNK PLASTIC</h1>
+        <a href="#" className="active">Dashboard</a>
+        <a href="#">Stocks</a>
+        <a href="#">Factures</a>
+        <a href="#">Suivi de production</a>
+      </aside>
+
+      <main className="main-content">
+        <h2 className="dashboard-title">Dashboard</h2>
+
+        <div className="filters-bar">
+          <DashboardFilters onFilterChange={setFilters} />
+        </div>
+
+        <DashboardKpis filters={filters} />
+
+        <h3>Ordres de fabrication actifs</h3>
+        <OFTable filters={filters} />
+      </main>
     </div>
   );
 }

--- a/SNK_Plastic/frontend/src/components/dashboard/OFTable.js
+++ b/SNK_Plastic/frontend/src/components/dashboard/OFTable.js
@@ -21,25 +21,23 @@ function OFTable({ filters }) {
   if (!ofs) return <p>Loading...</p>;
 
   return (
-    <div>
-      <h2>Ordres de fabrication actifs</h2>
-      <table>
-        <thead>
-          <tr>
-            <th>ID</th>
-            <th>Client</th>
-            <th>Machine</th>
+    <table className="of-table">
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Client</th>
+          <th>Machine</th>
             <th>Quantité commandée</th>
             <th>Quantité produite</th>
             <th>Rebuts</th>
             <th>Restant</th>
             <th>Temps écoulé</th>
-            <th>Statut</th>
-          </tr>
-        </thead>
-        <tbody>
-          {ofs.map((of) => (
-            <tr key={of.id}>
+          <th>Statut</th>
+        </tr>
+      </thead>
+      <tbody>
+        {ofs.map((of) => (
+          <tr key={of.id}>
               <td>{of.id}</td>
               <td>{of.client}</td>
               <td>{of.machine}</td>
@@ -48,12 +46,11 @@ function OFTable({ filters }) {
               <td style={{ color: of.rebuts > 0 ? 'red' : 'inherit' }}>{of.rebuts}</td>
               <td>{of.restant}</td>
               <td>{of.temps_ecoule}</td>
-              <td>{of.etat}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+            <td>{of.etat}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
   );
 }
 


### PR DESCRIPTION
## Summary
- add dashboard styles in a new `DashboardPage.css`
- overhaul Dashboard layout to use sidebar and main content sections
- format KPI and table components with modern classes

## Testing
- `npm test --silent --no-watch` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845e25b9cb0832cbd727a7aedc686f7